### PR TITLE
refactor: control monitor buffer size via environment variable

### DIFF
--- a/cmd/cgtproxy/cmd/providers.go
+++ b/cmd/cgtproxy/cmd/providers.go
@@ -64,7 +64,8 @@ func provideRuleManager(
 }
 
 func provideCgrougMontior(
-	cgroupRoot config.CGroupRoot, logger *zap.SugaredLogger,
+	cgroupRoot config.CGroupRoot,
+	logger *zap.SugaredLogger,
 ) (
 	interfaces.CGroupMonitor, error,
 ) {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
----
+## File exists
 
 ```
 Error:
@@ -16,7 +16,8 @@ The "file exists" is error message of EEXIST, which means that:
 
 2. Previous cgtproxy doesn't exit normally, perhaps killed with SIG_KILL.
 
-   A system reboot should fix this issue, if you don't want to do so read the instructions below:
+   A system reboot should fix this issue,
+   if you don't want to do so read the instructions below:
 
    1. Check what is exactly going on:
 
@@ -49,3 +50,59 @@ The "file exists" is error message of EEXIST, which means that:
       sudo nft flush table inet cgtproxy
       sudo nft delete table inet cgtproxy
       ```
+
+## Event Loss
+
+If you notice that some cgroup events are not being captured by cgtproxy,
+it might be due to event dropping in the filesystem monitor.
+This can happen when the event receiver is too slow to process events.
+
+You may observe the following symptoms:
+
+1. For creation events loss:
+   Some cgroups exist but have no corresponding rules in nftables.
+
+2. For deletion events loss:
+   You may find rules in nftables referencing cgroups with inode numbers
+   instead of paths when running `nft list ruleset`.
+   This happens because the kernel can only provide the inode number
+   when the cgroup path no longer exists in the filesystem.
+
+To check if you are experiencing event loss:
+
+```bash
+# List all cgroups under your target path
+find /sys/fs/cgroup/user.slice -type d
+
+# Check nft rules
+# If you see inode numbers in "meta cgroup" expressions instead of paths,
+# it means those cgroups have been deleted but cgtproxy missed the deletion events
+sudo nft list ruleset | grep cgroup
+```
+
+To mitigate this issue,
+you can increase the event buffer size by setting
+the `CGTPROXY_MONITOR_BUFFER_SIZE` environment variable.
+For example:
+
+```bash
+# Increase buffer size to 2048 (default is 1024)
+CGTPROXY_MONITOR_BUFFER_SIZE=2048 cgtproxy
+```
+
+You can also set this in the systemd service file
+by adding the environment variable:
+
+```ini
+[Service]
+Environment=CGTPROXY_MONITOR_BUFFER_SIZE=2048
+```
+
+Note that a larger buffer size will consume more memory
+but can handle more events in a short period.
+If you still experience event loss after increasing the buffer size,
+you might need to:
+
+1. Further increase the buffer size
+2. Check if your system is under heavy load
+3. Consider reducing the rate of cgroup creation/deletion if possible


### PR DESCRIPTION
- Add CGTPROXY_MONITOR_BUFFER_SIZE environment variable to control the buffer size of cgroup monitor\n- Add warning logs for invalid buffer size values\n- Add debug log to show current buffer size\n- Improve comments about event dropping issue\n- Format code\n\nThis change moves the buffer size control from hardcoded value to an environment variable, making it easier to tune and debug in different environments.