### PR TITLE
fix: correct ipv4 bypass set parsing

### DIFF
--- a/pkg/nftman/new.go
+++ b/pkg/nftman/new.go
@@ -259,7 +259,7 @@ func (nft *NFTManager) initIPV4BypassSet(conn *nftables.Conn) (err error) {
 					Key: ip.To4(),
 				},
 				nftables.SetElement{
-					Key:         nft.nextIP(ip).To4(),
+					Key:         nft.nextIP(ip.To4()),
 					IntervalEnd: true,
 				},
 			)


### PR DESCRIPTION
```go
func ParseIP(s string) IP {
	if addr, valid := parseIP(s); valid {
		return IP(addr[:])
	}
	return nil
}

func parseIP(s string) ([16]byte, bool) {
	ip, err := netip.ParseAddr(s)
	if err != nil || ip.Zone() != "" {
		return [16]byte{}, false
	}
	return ip.As16(), true
}
```

`net.ParseIP` will return 16byte representation for both V4 address and
V6 address.

`NextIP` generate next IP by plus ip address by one manually,
which make the next ip of 255.255.255.255 became ::1:0:0:0.

Call To4 before NextIP makes the next IP of 255.255.255.255 to be
0.0.0.0, which will not be rejected by kernel, as well as parsed as a
single 255.255.255.255 recorded by the `nft` program, which should works
well.

This is just a quick fix, I think we should have a more robust NextIP
implementation.

Related: #258
