### PR TITLE
chore: remove .prompts submodule and editor integration symlinks

### DIFF
--- a/.cursor/rules/Git.mdc
+++ b/.cursor/rules/Git.mdc
@@ -1,1 +1,0 @@
-../../.prompts/cursor/Git.mdc

--- a/.cursor/rules/Project instructions.mdc
+++ b/.cursor/rules/Project instructions.mdc
@@ -1,1 +1,0 @@
-../../.prompts/cursor/Project instructions.mdc

--- a/.cursor/rules/commitChanges.mdc
+++ b/.cursor/rules/commitChanges.mdc
@@ -1,1 +1,0 @@
-../../.prompts/cursor/commitChanges.mdc

--- a/.cursor/rules/createNewRepositoryFromTemplate.mdc
+++ b/.cursor/rules/createNewRepositoryFromTemplate.mdc
@@ -1,1 +1,0 @@
-../../.prompts/cursor/createNewRepositoryFromTemplate.mdc

--- a/.cursor/rules/fixReuseLint.mdc
+++ b/.cursor/rules/fixReuseLint.mdc
@@ -1,1 +1,0 @@
-../../.prompts/cursor/fixReuseLint.mdc

--- a/.cursor/rules/instructions.mdc
+++ b/.cursor/rules/instructions.mdc
@@ -1,1 +1,0 @@
-../../.prompts/cursor/instructions.mdc

--- a/.github/Git.prompt.md
+++ b/.github/Git.prompt.md
@@ -1,1 +1,0 @@
-../.prompts/github-copilot/Git.prompt.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,0 @@
-../.prompts/github-copilot/copilot-instructions.md

--- a/.github/prompts/commitChanges.prompt.md
+++ b/.github/prompts/commitChanges.prompt.md
@@ -1,1 +1,0 @@
-../../.prompts/github-copilot/commitChanges.prompt.md

--- a/.github/prompts/createNewRepositoryFromTemplate.prompt.md
+++ b/.github/prompts/createNewRepositoryFromTemplate.prompt.md
@@ -1,1 +1,0 @@
-../../.prompts/github-copilot/createNewRepositoryFromTemplate.prompt.md

--- a/.github/prompts/fixReuseLint.prompt.md
+++ b/.github/prompts/fixReuseLint.prompt.md
@@ -1,1 +1,0 @@
-../../.prompts/github-copilot/fixReuseLint.prompt.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-[submodule ".prompts"]
-	path = .prompts
-	url = https://github.com/black-desk/.prompts
 [submodule ".format"]
 	path = .format
 	url = https://github.com/black-desk/.format


### PR DESCRIPTION
Remove the .prompts submodule and all symlinks under .cursor/rules/
and .github/ that referenced it, as well as the corresponding
.gitmodules entry.

This commit message is generated by LLM, it might be wrong.
