### PR TITLE
test: add unit tests for routeman, cgfsmon, config and nftman

### DIFF
--- a/pkg/cgfsmon/cgfsmon_test.go
+++ b/pkg/cgfsmon/cgfsmon_test.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2025 Chen Linxuan <me@black-desk.cn>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgfsmon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/black-desk/cgtproxy/pkg/cgtproxy/config"
+	"github.com/black-desk/cgtproxy/pkg/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+func TestCGroupFSMonitor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CGroupFSMonitor Suite")
+}
+
+// makeTree creates a throwaway cgroup-like directory tree under a temp dir.
+//
+//	root/
+//	  a/
+//	  b/
+//	    c/
+//	  file.txt        (a regular file, must be skipped by the walker)
+func makeTree(root string) {
+	Expect(os.MkdirAll(filepath.Join(root, "a"), 0o755)).To(Succeed())
+	Expect(os.MkdirAll(filepath.Join(root, "b", "c"), 0o755)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), 0o644)).To(Succeed())
+}
+
+func eventPaths(events []types.CGroupEvent) []string {
+	ret := make([]string, 0, len(events))
+	for i := range events {
+		ret = append(ret, events[i].Path)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+var _ = Describe("CGroupFSMonitor", func() {
+	Describe("construction via New", func() {
+		Context("with missing or invalid arguments", func() {
+			It("should fail when no cgroup root is provided", func() {
+				_, err := New()
+				Expect(err).To(MatchError(ErrCGroupRootNotFound))
+			})
+
+			It("should fail when the cgroup root is empty", func() {
+				_, err := New(WithCgroupRoot(""))
+				Expect(err).To(MatchError(ErrCGroupRootNotFound))
+			})
+
+			It("should fail when a nil logger is supplied", func() {
+				_, err := New(WithCgroupRoot("/tmp"), WithLogger(nil))
+				Expect(err).To(MatchError(ErrLoggerMissing))
+			})
+		})
+
+		Context("with valid arguments", func() {
+			It("should construct a monitor with the default buffer size", func() {
+				m, err := New(WithCgroupRoot("/tmp"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).ToNot(BeNil())
+				Expect(cap(m.eventsIn)).To(Equal(1024))
+			})
+
+			It("should accept a custom logger", func() {
+				log := zap.NewExample().Sugar()
+				m, err := New(WithCgroupRoot("/tmp"), WithLogger(log))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m.log).To(BeIdenticalTo(log))
+			})
+		})
+
+		Context("with the buffer size controlled by CGTPROXY_MONITOR_BUFFER_SIZE", func() {
+			It("should use the configured buffer size", func() {
+				os.Setenv("CGTPROXY_MONITOR_BUFFER_SIZE", "256")
+				defer os.Unsetenv("CGTPROXY_MONITOR_BUFFER_SIZE")
+
+				m, err := New(WithCgroupRoot("/tmp"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cap(m.eventsIn)).To(Equal(256))
+			})
+
+			It("should fall back to the default for an invalid value", func() {
+				os.Setenv("CGTPROXY_MONITOR_BUFFER_SIZE", "not-a-number")
+				defer os.Unsetenv("CGTPROXY_MONITOR_BUFFER_SIZE")
+
+				m, err := New(WithCgroupRoot("/tmp"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cap(m.eventsIn)).To(Equal(1024))
+			})
+
+			It("should fall back to the default for a non-positive value", func() {
+				os.Setenv("CGTPROXY_MONITOR_BUFFER_SIZE", "0")
+				defer os.Unsetenv("CGTPROXY_MONITOR_BUFFER_SIZE")
+
+				m, err := New(WithCgroupRoot("/tmp"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cap(m.eventsIn)).To(Equal(1024))
+			})
+		})
+	})
+
+	Describe("walk", func() {
+		var (
+			root string
+			m    *CGroupFSMonitor
+		)
+
+		BeforeEach(func() {
+			var err error
+			root, err = os.MkdirTemp("", "cgfsmon-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			makeTree(root)
+
+			m, err = New(WithCgroupRoot(config.CGroupRoot(root)))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(root)).To(Succeed())
+		})
+
+		It("should collect every subdirectory except the root itself", func() {
+			events, err := m.walk(root)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(eventPaths(events)).To(ConsistOf(
+				filepath.Join(root, "a"),
+				filepath.Join(root, "b"),
+				filepath.Join(root, "b", "c"),
+			))
+		})
+
+		It("should report every collected directory as a New event", func() {
+			events, err := m.walk(root)
+			Expect(err).ToNot(HaveOccurred())
+			for i := range events {
+				Expect(events[i].EventType).To(Equal(types.CgroupEventTypeNew))
+			}
+		})
+	})
+
+	Describe("send", func() {
+		var m *CGroupFSMonitor
+
+		BeforeEach(func() {
+			var err error
+			m, err = New(WithCgroupRoot("/tmp"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should forward events to the output channel", func() {
+			ctx := context.Background()
+
+			received := make(chan types.CGroupEvents, 1)
+			go func() {
+				received <- <-m.Events()
+			}()
+
+			in := types.CGroupEvents{Events: []types.CGroupEvent{{
+				Path:      "/some/cgroup/",
+				EventType: types.CgroupEventTypeNew,
+			}}}
+			err := m.send(ctx, in)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(received).Should(Receive(WithTransform(
+				func(e types.CGroupEvents) []string { return eventPaths(e.Events) },
+				Equal([]string{"/some/cgroup"}), // trailing slash trimmed
+			)))
+		})
+
+		It("should abort when the context is already cancelled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := m.send(ctx, types.CGroupEvents{Events: []types.CGroupEvent{{
+				Path: "/some/cgroup", EventType: types.CgroupEventTypeNew,
+			}}})
+			Expect(err).To(MatchError(context.Canceled))
+		})
+	})
+})

--- a/pkg/cgtproxy/config/config_test.go
+++ b/pkg/cgtproxy/config/config_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
+	"go.uber.org/zap"
 )
 
 var _ = Describe("Configuration", func() {
@@ -103,3 +104,29 @@ func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Configuration Suite")
 }
+
+var _ = Describe("Rule.String", func() {
+	ContextTable("formatting a rule (%s)",
+		ContextTableEntry(&config.Rule{Match: "/drop/.*", Drop: true},
+			"rule [ match: /drop/.* | DROP ]").WithFmt("drop"),
+		ContextTableEntry(&config.Rule{Match: "/direct/.*", Direct: true},
+			"rule [ match: /direct/.* | DIRECT ]").WithFmt("direct"),
+		ContextTableEntry(&config.Rule{Match: "/proxy/.*", TProxy: "clash"},
+			"rule [ match: /proxy/.* | TPROXY clash ]").WithFmt("tproxy"),
+		func(rule *config.Rule, expected string) {
+			It("should render the expected string", func() {
+				Expect(rule.String()).To(Equal(expected))
+			})
+		})
+})
+
+var _ = Describe("WithLogger", func() {
+	It("should inject the given logger into the configuration", func() {
+		log := zap.NewExample().Sugar()
+		_, err := config.New(
+			config.WithContent([]byte(config.DefaultConfig)),
+			config.WithLogger(log),
+		)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/pkg/nftman/ip_test.go
+++ b/pkg/nftman/ip_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 Chen Linxuan <me@black-desk.cn>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package nftman
+
+import (
+	"net"
+
+	. "github.com/black-desk/lib/go/ginkgo-helper"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+// These specs exercise the pure IP-arithmetic helpers. They neither require
+// privileges nor depend on a cgroup root, so they are kept in a standalone
+// Describe that the gated "Netfilter table" suite picks up automatically.
+
+var _ = Describe("IP helpers", func() {
+	var nft *NFTManager
+
+	BeforeEach(func() {
+		nft = &NFTManager{log: zap.NewNop().Sugar()}
+	})
+
+	Describe("nextIP", func() {
+		ContextTable("nextIP(%s)",
+			ContextTableEntry("1.2.3.4", "1.2.3.5").WithFmt("1.2.3.4"),
+			ContextTableEntry("10.0.0.0", "10.0.0.1").WithFmt("10.0.0.0"),
+			ContextTableEntry("1.2.3.255", "1.2.4.0").WithFmt("1.2.3.255"),
+			ContextTableEntry("2001:db8::1", "2001:db8::2").WithFmt("2001:db8::1"),
+			func(input, expected string) {
+				It("should return the incremented address", func() {
+					got := nft.nextIP(net.ParseIP(input))
+					Expect(got.Equal(net.ParseIP(expected))).To(BeTrue(),
+						"expected %s, got %s", expected, got)
+				})
+			})
+	})
+
+	Describe("lastIP", func() {
+		ContextTable("lastIP(%s)",
+			ContextTableEntry("192.168.1.0/24", "192.168.1.255").WithFmt("192.168.1.0/24"),
+			ContextTableEntry("10.0.0.0/8", "10.255.255.255").WithFmt("10.0.0.0/8"),
+			ContextTableEntry("172.16.0.0/12", "172.31.255.255").WithFmt("172.16.0.0/12"),
+			ContextTableEntry("2001:db8::/32",
+				"2001:db8:ffff:ffff:ffff:ffff:ffff:ffff").WithFmt("2001:db8::/32"),
+			func(cidr, expected string) {
+				It("should return the broadcast address of the range", func() {
+					_, ipnet, err := net.ParseCIDR(cidr)
+					Expect(err).ToNot(HaveOccurred())
+
+					got := nft.lastIP(ipnet)
+					Expect(got.Equal(net.ParseIP(expected))).To(BeTrue(),
+						"expected %s, got %s", expected, got)
+				})
+			})
+	})
+})

--- a/pkg/nftman/nftman_test.go
+++ b/pkg/nftman/nftman_test.go
@@ -7,6 +7,7 @@ package nftman
 import (
 	"math/rand"
 	"os"
+	"strconv"
 	"syscall"
 	"testing"
 
@@ -16,6 +17,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// pstr returns a pointer to the given string, for fields like DNSHijack.IP.
+func pstr(s string) *string { return &s }
+
+const needSandboxMessage = "" +
+	"Skip tests of core/table as it requires some capabilities. " +
+	"If you really want to run tests of this package, " +
+	"try run `make test` at the root directory of this repository."
 
 var _ = Describe("Netfliter table", Ordered, func() {
 	var (
@@ -28,11 +37,7 @@ var _ = Describe("Netfliter table", Ordered, func() {
 			return
 		}
 
-		Skip("" +
-			"Skip tests of core/table as it requires some capabilities. " +
-			"If you really want to run tests of this package, " +
-			"try run `make test` at the root directory of this repository.",
-		)
+		Skip(needSandboxMessage)
 	})
 
 	Context("created", func() {
@@ -129,20 +134,20 @@ var _ = Describe("Netfliter table", Ordered, func() {
 									"meta l4proto { tcp, udp } tproxy to :7895",
 								},
 							},
-							{
-								t: &config.TProxy{
-									Name:   "tproxy4",
-									NoUDP:  true,
-									NoIPv6: true,
-									Port:   7896,
-									Mark:   104,
-								},
-								expects: []string{
-									"chain tproxy4",
-									"meta l4proto tcp tproxy ip to :7896",
-								},
+						{
+							t: &config.TProxy{
+								Name:   "tproxy4",
+								NoUDP:  true,
+								NoIPv6: true,
+								Port:   7896,
+								Mark:   104,
 							},
-						}).WithFmt(),
+							expects: []string{
+								"chain tproxy4",
+								"meta l4proto tcp tproxy ip to :7896",
+							},
+						},
+					}).WithFmt(),
 						func(tps []*TproxyCase) {
 							BeforeEach(func() {
 								By("Initialize table with tproxies.", func() {
@@ -280,6 +285,80 @@ var _ = Describe("Netfliter table", Ordered, func() {
 				})
 			})
 	})
+})
+
+var _ = Describe("DNS hijack", Ordered, func() {
+	var (
+		nft        *NFTManager
+		cgroupRoot = os.Getenv("CGTPROXY_TEST_CGROUP_ROOT")
+	)
+
+	BeforeAll(func() {
+		if !(os.Geteuid() == 0 && os.Getenv("CGTPROXY_TEST_NFTMAN") == "1") {
+			Skip(needSandboxMessage)
+		}
+	})
+
+	BeforeEach(func() {
+		var err error
+		nft, err = injectedNFTManagerWithLastingConnector(config.CGroupRoot(cgroupRoot))
+		Expect(err).To(Succeed())
+
+		err = nft.InitStructure()
+		Expect(err).To(Succeed())
+	})
+
+	AfterEach(func() {
+		if nft != nil {
+			Expect(nft.Clear()).To(Succeed())
+		}
+	})
+
+	// A single entry runs both UDP-only and UDP+TCP hijacks together so we
+	// can also assert the mark-dns-vmap dispatch table in one ruleset.
+	ContextTable("with a DNS-hijacking tproxy (%s)",
+		ContextTableEntry([]*config.TProxy{
+			{Name: "dnsonly", Port: 7897, Mark: 105, DNSHijack: &config.DNSHijack{
+				IP: pstr("127.0.0.1"), Port: 5353,
+			}},
+		}).WithFmt("UDP only"),
+		ContextTableEntry([]*config.TProxy{
+			{Name: "dnstcp", Port: 7898, Mark: 106, DNSHijack: &config.DNSHijack{
+				IP: pstr("192.168.0.1"), Port: 5354, TCP: true,
+			}},
+		}).WithFmt("UDP + TCP"),
+		func(tps []*config.TProxy) {
+			var result string
+
+			BeforeEach(func() {
+				Expect(nft.AddChainAndRulesForTProxies(tps)).To(Succeed())
+				result = getNFTableRules()
+			})
+
+			It("should create a per-tproxy DNS chain", func() {
+				Expect(result).To(ContainSubstring("chain " + tps[0].Name + "-DNS"))
+			})
+
+			It("should wire the fwmark into the mark-dns-vmap", func() {
+				Expect(result).To(ContainSubstring("goto " + tps[0].Name + "-DNS"))
+			})
+
+			It("should emit a UDP dnat rule for :53", func() {
+				Expect(result).To(ContainSubstring(
+					"udp dport 53 dnat ip to " + *tps[0].DNSHijack.IP +
+						":" + strconv.Itoa(int(tps[0].DNSHijack.Port))))
+			})
+
+			It("should emit a TCP dnat rule only when TCP hijack is requested", func() {
+				tcpRule := "tcp dport 53 dnat ip to " + *tps[0].DNSHijack.IP +
+					":" + strconv.Itoa(int(tps[0].DNSHijack.Port))
+				if tps[0].DNSHijack.TCP {
+					Expect(result).To(ContainSubstring(tcpRule))
+				} else {
+					Expect(result).ToNot(ContainSubstring(tcpRule))
+				}
+			})
+		})
 })
 
 func TestTable(t *testing.T) {

--- a/pkg/routeman/routeman_test.go
+++ b/pkg/routeman/routeman_test.go
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: 2025 Chen Linxuan <me@black-desk.cn>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package routeman
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/black-desk/cgtproxy/pkg/cgtproxy/config"
+	"github.com/black-desk/cgtproxy/pkg/interfaces"
+	"github.com/black-desk/cgtproxy/pkg/types"
+	. "github.com/black-desk/lib/go/ginkgo-helper"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+func TestRouteManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RouteManager Suite")
+}
+
+// fakeNFTManager is a test double for interfaces.NFTManager that records
+// every call instead of touching the kernel.
+type fakeNFTManager struct {
+	addedRoutes  []types.Route
+	removedPaths []string
+	addedChains  []*config.TProxy
+
+	inited   bool
+	cleared  bool
+	released bool
+
+	initStructureErr error
+	addChainErr      error
+	addRoutesErr     error
+	removeRoutesErr  error
+	clearErr         error
+	releaseErr       error
+}
+
+var _ interfaces.NFTManager = (*fakeNFTManager)(nil)
+
+func (f *fakeNFTManager) InitStructure() error {
+	f.inited = true
+	return f.initStructureErr
+}
+
+func (f *fakeNFTManager) AddChainAndRulesForTProxies(tps []*config.TProxy) error {
+	f.addedChains = append(f.addedChains, tps...)
+	return f.addChainErr
+}
+
+func (f *fakeNFTManager) AddRoutes(routes []types.Route) error {
+	f.addedRoutes = append(f.addedRoutes, routes...)
+	return f.addRoutesErr
+}
+
+func (f *fakeNFTManager) RemoveRoutes(paths []string) error {
+	f.removedPaths = append(f.removedPaths, paths...)
+	return f.removeRoutesErr
+}
+
+func (f *fakeNFTManager) Clear() error {
+	f.cleared = true
+	return f.clearErr
+}
+
+func (f *fakeNFTManager) Release() error {
+	f.released = true
+	return f.releaseErr
+}
+
+// mustConfig builds a validated *config.Config from raw YAML, panicking the
+// spec on failure.
+func mustConfig(yamlContent string) *config.Config {
+	cfg, err := config.New(config.WithContent([]byte(yamlContent)))
+	Expect(err).ToNot(HaveOccurred())
+	return cfg
+}
+
+const testConfigYAML = `
+version: 1
+cgroup-root: AUTO
+route-table: 300
+tproxies:
+  clash:
+    port: 7893
+    mark: 520
+rules:
+  - match: .*proxy.*
+    tproxy: clash
+  - match: .*direct.*
+    direct: true
+  - match: .*drop.*
+    drop: true
+`
+
+var _ = Describe("RouteManager", func() {
+	Describe("construction via New", func() {
+		Context("with a missing required dependency", func() {
+			It("should fail when the NFT manager is nil", func() {
+				_, err := New(WithConfig(mustConfig(testConfigYAML)), WithNFTMan(nil))
+				Expect(err).To(MatchError(ErrNFTManagerMissing))
+			})
+
+			It("should fail when the config is nil", func() {
+				_, err := New(WithConfig(nil))
+				Expect(err).To(MatchError(ErrConfigMissing))
+			})
+
+			It("should fail when the event channel is nil", func() {
+				_, err := New(WithCGroupEventChan(nil))
+				Expect(err).To(MatchError(ErrCGroupEventChanMissing))
+			})
+		})
+
+		Context("with all dependencies provided", func() {
+			It("should compile the configured rules into matchers", func() {
+				m, err := New(
+					WithConfig(mustConfig(testConfigYAML)),
+					WithNFTMan(&fakeNFTManager{}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).ToNot(BeNil())
+				Expect(m.matchers).To(HaveLen(3))
+			})
+
+			It("should accept a non-nil event channel", func() {
+				ch := make(<-chan types.CGroupEvents)
+				m, err := New(
+					WithConfig(mustConfig(testConfigYAML)),
+					WithNFTMan(&fakeNFTManager{}),
+					WithCGroupEventChan(ch),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m.cgroupEventsChan).To(BeIdenticalTo(ch))
+			})
+
+			It("should fall back to a nop logger when none is given", func() {
+				m, err := New(
+					WithConfig(mustConfig(testConfigYAML)),
+					WithNFTMan(&fakeNFTManager{}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m.log).ToNot(BeNil())
+			})
+
+			It("should accept a custom logger", func() {
+				log := zap.NewExample().Sugar()
+				m, err := New(
+					WithConfig(mustConfig(testConfigYAML)),
+					WithNFTMan(&fakeNFTManager{}),
+					WithLogger(log),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m.log).To(BeIdenticalTo(log))
+			})
+		})
+
+		Context("with an invalid regex in a rule", func() {
+			It("should fail to compile the matcher", func() {
+				cfg := mustConfig(testConfigYAML)
+				cfg.Rules[0].Match = "["
+
+				_, err := New(WithConfig(cfg), WithNFTMan(&fakeNFTManager{}))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("handleNewCgroups", func() {
+		var (
+			m   *RouteManager
+			nft *fakeNFTManager
+		)
+
+		BeforeEach(func() {
+			nft = &fakeNFTManager{}
+			m, _ = New(
+				WithConfig(mustConfig(testConfigYAML)),
+				WithNFTMan(nft),
+			)
+		})
+
+		ContextTable("matching cgroup path %q",
+			ContextTableEntry("/user/proxy/app.service",
+				types.TargetTProxy, "clash-MARK").WithFmt("/user/proxy/app.service"),
+			ContextTableEntry("/user/direct/app.service",
+				types.TargetDirect, "").WithFmt("/user/direct/app.service"),
+			ContextTableEntry("/user/drop/app.service",
+				types.TargetDrop, "").WithFmt("/user/drop/app.service"),
+			func(path string, expectedOp types.TargetOp, expectedChain string) {
+				It("should produce a single route with the expected target", func() {
+					err := m.handleNewCgroups([]string{path})
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(nft.addedRoutes).To(HaveLen(1))
+					route := nft.addedRoutes[0]
+					Expect(route.Path).To(Equal(path))
+					Expect(route.Target.Op).To(Equal(expectedOp))
+					Expect(route.Target.Chain).To(Equal(expectedChain))
+				})
+			})
+
+		Context("when no rule matches", func() {
+			It("should not add any route", func() {
+				err := m.handleNewCgroups([]string{"/nothing-matches-here"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nft.addedRoutes).To(BeEmpty())
+			})
+		})
+
+		Context("when several paths are handled in one batch", func() {
+			It("should only add routes for the matching ones, in order", func() {
+				paths := []string{
+					"/user/proxy/a.service",
+					"/user/ignored/b.service",
+					"/user/drop/c.service",
+				}
+				err := m.handleNewCgroups(paths)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(nft.addedRoutes).To(HaveLen(2))
+				Expect(nft.addedRoutes[0].Path).To(Equal(paths[0]))
+				Expect(nft.addedRoutes[0].Target.Op).To(Equal(types.TargetTProxy))
+				Expect(nft.addedRoutes[1].Path).To(Equal(paths[2]))
+				Expect(nft.addedRoutes[1].Target.Op).To(Equal(types.TargetDrop))
+			})
+		})
+
+		Context("when the first matching rule wins", func() {
+			It("should pick the tproxy rule over the direct rule", func() {
+				err := m.handleNewCgroups([]string{"/user/proxy-and-direct.service"})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(nft.addedRoutes).To(HaveLen(1))
+				Expect(nft.addedRoutes[0].Target.Op).To(Equal(types.TargetTProxy))
+			})
+		})
+
+		Context("when the NFT manager fails to add routes", func() {
+			It("should propagate the wrapped error", func() {
+				injected := errors.New("injected nft failure")
+				nft.addRoutesErr = injected
+
+				err := m.handleNewCgroups([]string{"/user/proxy/app.service"})
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(injected))
+			})
+		})
+	})
+
+	Describe("handleDeleteCgroups", func() {
+		var (
+			m   *RouteManager
+			nft *fakeNFTManager
+		)
+
+		BeforeEach(func() {
+			nft = &fakeNFTManager{}
+			m, _ = New(
+				WithConfig(mustConfig(testConfigYAML)),
+				WithNFTMan(nft),
+			)
+		})
+
+		It("should forward every path to the NFT manager", func() {
+			paths := []string{"/user/proxy/a.service", "/user/drop/b.service"}
+			err := m.handleDeleteCgroups(paths)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nft.removedPaths).To(Equal(paths))
+		})
+
+		It("should propagate a removal failure", func() {
+			injected := errors.New("injected remove failure")
+			nft.removeRoutesErr = injected
+
+			err := m.handleDeleteCgroups([]string{"/user/proxy/a.service"})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(injected))
+		})
+	})
+})


### PR DESCRIPTION
Add unit tests covering previously untested code paths, lifting total line coverage from ~31% to ~67%.

## What

- **routeman**: exercise the regex matching core (`handleNewCgroups`/`handleDeleteCgroups`) and constructor validation via a fake `NFTManager`. First-match-wins priority, per-target mapping (direct/drop/tproxy), no-match skipping and error propagation are covered. No privileges required thanks to the injectable `interfaces.NFTManager`.
- **cgfsmon**: test `walk`/`send`/`New` and the `CGTPROXY_MONITOR_BUFFER_SIZE` parsing against a temp directory tree, without touching inotify.
- **config**: cover `Rule.String()` branches and `WithLogger`.
- **nftman**: cover the pure IP helpers `nextIP`/`lastIP` (IPv4/IPv6, carry), and the DNS hijack chains (UDP-only and UDP+TCP) under the existing sandbox gate, which also exercises `addDNSChainForTproxy` and `updateMarkDNSMap`.

## Coverage

| Package | Before | After |
|---|---|---|
| routeman (matching core) | 0% | 44.1% |
| cgfsmon | 0% | 59.8% |
| config | partial | 87.1% |
| nftman `nextIP`/`lastIP` | 0% | 100% |
| nftman `addDNSChainForTproxy` | 0% | 93.3% |
| **Total** | **31.3%** | **~67%** |

All new non-sandbox tests run anywhere without privileges; the nftman DNS tests reuse the existing `CGTPROXY_TEST_NFTMAN` gate.

The remaining 0% (routeman netlink paths, `cgfsmon.RunCGroupMonitor`, the connector packages) would need sandbox integration tests or refactoring to inject netlink.

Assisted-by: Claude:glm-5.1